### PR TITLE
Reduce maven-assembly-plugin dependency version to 2.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,7 +266,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>2.5.3</version>
+          <version>2.5.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This should fix a build problem on OSX similar to that reported here
https://github.com/nmdp-bioinformatics/ngs/issues/78