### PR TITLE
Update namespacePrefix for liftover service

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Genotype List service, client library, and command line tools.
 [![Build Status](https://travis-ci.org/nmdp-bioinformatics/genotype-list.svg?branch=master)](https://travis-ci.org/nmdp-bioinformatics/genotype-list)
 
 
-###Hacking genotype-list
+### Hacking genotype-list
 
 Install
 

--- a/gl-liftover-service/src/main/java/org/nmdp/gl/liftover/impl/LiftoverServiceModule.java
+++ b/gl-liftover-service/src/main/java/org/nmdp/gl/liftover/impl/LiftoverServiceModule.java
@@ -83,7 +83,7 @@ public final class LiftoverServiceModule extends AbstractModule {
 
     @Provides @LocusNames @Singleton
     Table<String, String, String> createLocusNames() {
-        AllelelistHistoryReader allelelistHistoryReader = new AllelelistHistoryReader("https://gl.immunogenomics.org/imgt-hla/");
+        AllelelistHistoryReader allelelistHistoryReader = new AllelelistHistoryReader("https://gl.nmdp.org/imgt-hla/");
         try {
             allelelistHistoryReader.readAllelelistHistory();
             allelelistHistoryReader.readGgroups();
@@ -96,7 +96,7 @@ public final class LiftoverServiceModule extends AbstractModule {
 
     @Provides @AlleleNames @Singleton
     Table<String, String, String> createAlleleNames() {
-        AllelelistHistoryReader allelelistHistoryReader = new AllelelistHistoryReader("https://gl.immunogenomics.org/imgt-hla/");
+        AllelelistHistoryReader allelelistHistoryReader = new AllelelistHistoryReader("https://gl.nmdp.org/imgt-hla/");
         try {
             allelelistHistoryReader.readAllelelistHistory();
             allelelistHistoryReader.readGgroups();


### PR DESCRIPTION
With this fix, liftover service works for me locally

```bash
$ curl -v \
  --header "content-type: text/plain" \
  -d '{"sourceNamespace":"http://gl.nmdp.org/imgt-hla/3.20.0/",  "sourceUri":"http://gl.nmdp.org/imgt-hla/3.20.0/allele/z9",  "targetNamespace":"https://gl.nmdp.org/imgt-hla/3.23.0/"}' \
  http://localhost:8080/liftover/allele
*   Trying ::1...
* Connected to localhost (::1) port 8080 (#0)
> POST /liftover/allele HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.43.0
> Accept: */*
> content-type: text/plain
> Content-Length: 177
> 
* upload completely sent off: 177 out of 177 bytes
< HTTP/1.1 200 OK
< Content-Type: application/json
< Content-Length: 239
< Server: Jetty(9.4.2.v20170220)
< 
* Connection #0 to host localhost left intact
{"sourceNamespace":"http://gl.nmdp.org/imgt-hla/3.20.0/"}
{"sourceUri":"http://gl.nmdp.org/imgt-hla/3.20.0/allele/z9"}
{"targetNamespace":"https://gl.nmdp.org/imgt-hla/3.23.0/"}
{"targetUri":"https://gl.nmdp.org/imgt-hla/3.23.0/allele/zs"}
```